### PR TITLE
Fix unclaimed portals visibility

### DIFF
--- a/ice/modules/ice-50-extra.js
+++ b/ice/modules/ice-50-extra.js
@@ -67,7 +67,7 @@ function addTimestamp(time, iitcz) {
 function addIitc() {
   page.evaluate(function(field, link, res, enl, min, max) {
     localStorage['ingress.intelmap.layergroupdisplayed'] = JSON.stringify({
-      "Unclaimed Portals":Boolean(min === 1),
+      "Unclaimed/Placeholder Portals":Boolean(min === 1),
       "Level 1 Portals":Boolean(min === 1),
       "Level 2 Portals":Boolean((min <= 2) && (max >= 2)),
       "Level 3 Portals":Boolean((min <= 3) && (max >= 3)),


### PR DESCRIPTION
With recent changes to IITC now the field of "Unclaimed Portals" is named "Unclaimed/Placeholder Portals". Without this fix unclaimed portals are always visible regardless of config.
Closes #5 